### PR TITLE
Rename workflow step to "Install uv"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - name: Install pypa/build
+      - name: Install uv
         run: >-
           python3 -m
           pip install


### PR DESCRIPTION
Update the publish.yml GitHub Actions workflow by renaming the step
from "Install pypa/build" to "Install uv" to accurately describe the
package being installed during the Python setup process.
